### PR TITLE
string.characters.count -> characters.count

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -148,7 +148,7 @@ class FormatterExample : FormViewController {
         }
         
         func getNewPosition(forPosition position: UITextPosition, inTextInput textInput: UITextInput, oldValue: String?, newValue: String?) -> UITextPosition {
-            return textInput.position(from: position, offset:((newValue?.characters.count ?? 0) - (oldValue?.characters.count ?? 0))) ?? position
+            return textInput.position(from: position, offset:((newValue?.count ?? 0) - (oldValue?.count ?? 0))) ?? position
         }
         
     }


### PR DESCRIPTION
Fixes #issue(s) .
Xcode 9.1 Compiler warnings. 

Changes proposed in this request:
* 2x cases of string.characters.count -> string.count